### PR TITLE
adding CNAI group

### DIFF
--- a/cncf/settings.yml
+++ b/cncf/settings.yml
@@ -217,6 +217,9 @@ groups:
   - name: Wasm
     categories:
       - Wasm
+  - name: Cloud Native Artificial Intelligence
+    categories:
+      - CNAI
 
 # Header (optional)
 #

--- a/cncf/settings.yml
+++ b/cncf/settings.yml
@@ -217,7 +217,7 @@ groups:
   - name: Wasm
     categories:
       - Wasm
-  - name: Cloud Native Artificial Intelligence
+  - name: CNAI
     categories:
       - CNAI
 


### PR DESCRIPTION
This is part 1 of the two PRs to create a Cloud Native Artificial Intelligence subcategory on the landscape. The second part will be in the "cncf/landscape" repo with the actual data.