### PR TITLE
Fix typo in `settings.yml` file comments

### DIFF
--- a/ccc/settings.yml
+++ b/ccc/settings.yml
@@ -277,7 +277,7 @@ screenshot_width: 1500
 # Projects items can specify which TAG owns them in the `landscape.yml` file
 # (by using the `tag` field in the `extra` item's section). However, sometimes
 # this information is not available at the item level. This configuration
-# section provides a mechanism to automatically asign a TAG to projects items
+# section provides a mechanism to automatically assign a TAG to projects items
 # based on the categories and subcategories they belong to.
 #
 # For example, we can define that all projects in the category <CATEGORY1> are

--- a/cncf/settings.yml
+++ b/cncf/settings.yml
@@ -351,7 +351,7 @@ screenshot_width: 3000
 # Projects items can specify which TAG owns them in the `landscape.yml` file
 # (by using the `tag` field in the `extra` item's section). However, sometimes
 # this information is not available at the item level. This configuration
-# section provides a mechanism to automatically asign a TAG to projects items
+# section provides a mechanism to automatically assign a TAG to projects items
 # based on the categories and subcategories they belong to.
 #
 # For example, we can define that all projects in the category <CATEGORY1> are

--- a/lf/settings.yml
+++ b/lf/settings.yml
@@ -306,7 +306,7 @@ screenshot_width: 3000
 # Projects items can specify which TAG owns them in the `landscape.yml` file
 # (by using the `tag` field in the `extra` item's section). However, sometimes
 # this information is not available at the item level. This configuration
-# section provides a mechanism to automatically asign a TAG to projects items
+# section provides a mechanism to automatically assign a TAG to projects items
 # based on the categories and subcategories they belong to.
 #
 # For example, we can define that all projects in the category <CATEGORY1> are

--- a/lfnetworking/settings.yml
+++ b/lfnetworking/settings.yml
@@ -289,7 +289,7 @@ screenshot_width: 1500
 # Projects items can specify which TAG owns them in the `landscape.yml` file
 # (by using the `tag` field in the `extra` item's section). However, sometimes
 # this information is not available at the item level. This configuration
-# section provides a mechanism to automatically asign a TAG to projects items
+# section provides a mechanism to automatically assign a TAG to projects items
 # based on the categories and subcategories they belong to.
 #
 # For example, we can define that all projects in the category <CATEGORY1> are

--- a/o3df/settings.yml
+++ b/o3df/settings.yml
@@ -276,7 +276,7 @@ screenshot_width: 1500
 # Projects items can specify which TAG owns them in the `landscape.yml` file
 # (by using the `tag` field in the `extra` item's section). However, sometimes
 # this information is not available at the item level. This configuration
-# section provides a mechanism to automatically asign a TAG to projects items
+# section provides a mechanism to automatically assign a TAG to projects items
 # based on the categories and subcategories they belong to.
 #
 # For example, we can define that all projects in the category <CATEGORY1> are

--- a/omp/settings.yml
+++ b/omp/settings.yml
@@ -311,7 +311,7 @@ screenshot_width: 1500
 # Projects items can specify which TAG owns them in the `landscape.yml` file
 # (by using the `tag` field in the `extra` item's section). However, sometimes
 # this information is not available at the item level. This configuration
-# section provides a mechanism to automatically asign a TAG to projects items
+# section provides a mechanism to automatically assign a TAG to projects items
 # based on the categories and subcategories they belong to.
 #
 # For example, we can define that all projects in the category <CATEGORY1> are

--- a/overturemaps/settings.yml
+++ b/overturemaps/settings.yml
@@ -278,7 +278,7 @@ screenshot_width: 1500
 # Projects items can specify which TAG owns them in the `landscape.yml` file
 # (by using the `tag` field in the `extra` item's section). However, sometimes
 # this information is not available at the item level. This configuration
-# section provides a mechanism to automatically asign a TAG to projects items
+# section provides a mechanism to automatically assign a TAG to projects items
 # based on the categories and subcategories they belong to.
 #
 # For example, we can define that all projects in the category <CATEGORY1> are

--- a/pqca/settings.yml
+++ b/pqca/settings.yml
@@ -277,7 +277,7 @@ screenshot_width: 1500
 # Projects items can specify which TAG owns them in the `landscape.yml` file
 # (by using the `tag` field in the `extra` item's section). However, sometimes
 # this information is not available at the item level. This configuration
-# section provides a mechanism to automatically asign a TAG to projects items
+# section provides a mechanism to automatically assign a TAG to projects items
 # based on the categories and subcategories they belong to.
 #
 # For example, we can define that all projects in the category <CATEGORY1> are

--- a/spdx/settings.yml
+++ b/spdx/settings.yml
@@ -266,7 +266,7 @@ screenshot_width: 1500
 # Projects items can specify which TAG owns them in the `landscape.yml` file
 # (by using the `tag` field in the `extra` item's section). However, sometimes
 # this information is not available at the item level. This configuration
-# section provides a mechanism to automatically asign a TAG to projects items
+# section provides a mechanism to automatically assign a TAG to projects items
 # based on the categories and subcategories they belong to.
 #
 # For example, we can define that all projects in the category <CATEGORY1> are


### PR DESCRIPTION
Fix typo: `asign` to `assign` in settings.yml files.