### PR TITLE
fix FINOS landscape URL

### DIFF
--- a/finos/settings.yml
+++ b/finos/settings.yml
@@ -19,7 +19,7 @@ foundation: FINOS
 #
 # url: <LANDSCAPE_URL>
 #
-url: https://finos.landscape2.io
+url: https://landscape.finos.org
 
 # Analytics (optional)
 #


### PR DESCRIPTION
https://landscape.finos.org/ is currently failing; this change should fix it.