### PR TITLE
Update Slack link

### DIFF
--- a/finos/settings.yml
+++ b/finos/settings.yml
@@ -162,7 +162,7 @@ footer:
     github: "https://github.com/finos"
     homepage: "https://www.finos.org"
     linkedin: "https://www.linkedin.com/company/finosfoundation"
-    slack: "https://lfaifoundation.slack.com/"
+    slack: "https://finos-lf.slack.com"
     twitter: "https://twitter.com/finosfoundation"
     youtube: "https://www.youtube.com/channel/UCfJAdRALzJ7J7snubrb_Y-Q"
   logo: "https://cncf.github.io/landscape2-sites/finos/logo_footer.svg"


### PR DESCRIPTION
Current Slack link is for the AI foundation not FINOS