### PR TITLE
Update CAMARA landscape settings: add category ordering and subcategory overrides

### DIFF
--- a/camara/settings.yml
+++ b/camara/settings.yml
@@ -204,6 +204,11 @@ grid_items_size: large
 #       - <CATEGORY2_NAME>
 #
 categories:
+  - name: Members
+    subcategories:
+      - Premier
+      - General
+      - Associate
   - name: Planning
     subcategories:
       - Research Partners

--- a/camara/settings.yml
+++ b/camara/settings.yml
@@ -199,10 +199,26 @@ groups:
 
   - name: Organizations
     categories:
-      - Planning
-      - Integration
-      - Solution Provider
-      - Operation
+  - name: Planning
+    subcategories:
+      - Research Partners
+      - Ecosystem Consultants & Training Partners
+      - Associations
+  - name: Integration
+    subcategories:
+      - System Integrators
+  - name: Solution Provider
+    subcategories:
+      - Network Capability Solution Providers
+      - Transformation Function Solution Providers
+      - API Exposure Platform Solution Providers
+      - Portal Solution Providers
+      - Independent Software Vendors
+  - name: Operation
+    subcategories:
+      - Operators
+      - Hyperscalers, CPaaS Providers, Aggregators
+      - API Customers
 # Header (optional)
 #
 # This section allows customizing some aspects of the header.

--- a/camara/settings.yml
+++ b/camara/settings.yml
@@ -135,7 +135,18 @@ colors:
 #       groups:
 #         - <GROUP_NAME>
 #
-
+featured_items:
+  - field: subcategory
+    options:
+      - value: Premier
+        order: 1
+        label: Premier
+      - value: General
+        order: 2
+        label: General
+      - value: Associate
+        order: 3
+        label: Associate
 # Footer (optional)
 #
 # This section allows customizing some aspects of the footer.
@@ -192,13 +203,7 @@ grid_items_size: large
 #       - <CATEGORY1_NAME>
 #       - <CATEGORY2_NAME>
 #
-groups:
-  - name: Members
-    categories:
-      - Members
-
-  - name: Organizations
-    categories:
+categories:
   - name: Planning
     subcategories:
       - Research Partners
@@ -219,6 +224,18 @@ groups:
       - Operators
       - Hyperscalers, CPaaS Providers, Aggregators
       - API Customers
+
+groups:
+  - name: Members
+    categories:
+      - Members
+
+  - name: Organizations
+    categories:
+      - Planning
+      - Integration
+      - Solution Provider
+      - Operation
 # Header (optional)
 #
 # This section allows customizing some aspects of the header.


### PR DESCRIPTION
Adds category and subcategory ordering overrides to the CAMARA landscape settings. This controls the display order of subcategories within each category in the Organizations group, aligning the landscape with the intended CAMARA ecosystem structure. The Members category subcategory order is also explicitly defined to ensure Premier, General, and Associate members are displayed in the correct order.